### PR TITLE
fix(production.rb): according to heroku, the user name is the name 'a…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     # TODO, Check the user name
-    :user_name => 'fidelity-plan-sendgrid', # This is the string literal 'apikey', NOT the ID of your API key
+    :user_name => 'apikey', # This is the string literal 'apikey', NOT the ID of your API key
     :password => ENV['SENDGRID_API_KEY'], # This is the secret sendgrid API key which was issued during API key creation
     :domain => 'fidelity-plan.com',
     :address => 'smtp.sendgrid.net',


### PR DESCRIPTION
…pikey' always